### PR TITLE
Implement wrap around technique in intra IMT interference calculation

### DIFF
--- a/sharc/parameters/parameters.ini
+++ b/sharc/parameters/parameters.ini
@@ -34,6 +34,9 @@ suppress_large_results = True
 # "INDOOR"
 topology = HOTSPOT
 ###########################################################################
+# Enable wrap around. Available only for "MACROCELL" and "HOTSPOT" topologies
+wrap_around = false
+###########################################################################
 # Number of macrocell sites per cluster (must set to 19 in macrocell network)
 num_macrocell_sites = 19
 ###########################################################################
@@ -521,7 +524,7 @@ clutter_loss = true
 [FS]
 ###########################################################################
 # x-y coordinates [m]
-x = 000
+x = 1000
 y = 0
 ###########################################################################
 # antenna height [m]

--- a/sharc/parameters/parameters.py
+++ b/sharc/parameters/parameters.py
@@ -67,6 +67,7 @@ class Parameters(object):
         # IMT
         #######################################################################
         self.imt.topology                = config.get("IMT", "topology")
+        self.imt.wrap_around             = config.getboolean("IMT", "wrap_around")
         self.imt.num_macrocell_sites     = config.getint("IMT", "num_macrocell_sites")
         self.imt.num_clusters            = config.getint("IMT", "num_clusters")
         self.imt.intersite_distance      = config.getfloat("IMT", "intersite_distance")

--- a/sharc/simulation.py
+++ b/sharc/simulation.py
@@ -44,6 +44,11 @@ class Simulation(ABC, Observable):
             self.param_system = self.parameters.rns
         elif self.parameters.general.system == "RAS":
             self.param_system = self.parameters.ras
+            
+        self.wrap_around_enabled = self.parameters.imt.wrap_around and \
+                                  (self.parameters.imt.topology == 'MACROCELL' \
+                                   or self.parameters.imt.topology == 'HOTSPOT') and \
+                                   self.parameters.imt.num_clusters == 1
 
         self.co_channel = self.parameters.general.enable_cochannel
         self.adjacent_channel = self.parameters.general.enable_adjacent_channel
@@ -73,6 +78,8 @@ class Simulation(ABC, Observable):
         self.imt_bs_bs_antenna_gain = list()
         self.imt_ue_ue_antenna_gain = list()
 
+        self.bs_to_ue_d_2D = np.empty(0)
+        self.bs_to_ue_d_3D = np.empty(0)
         self.bs_to_ue_phi = np.empty(0)
         self.bs_to_ue_theta = np.empty(0)
         self.bs_to_ue_beam_rbs = np.empty(0)
@@ -175,16 +182,6 @@ class Simulation(ABC, Observable):
         Result is returned as a numpy array with dimensions num_a x num_b
         TODO: calculate coupling loss between activa stations only
         """
-        # Calculate distance from transmitters to receivers. The result is a
-        # num_bs x num_ue array
-        d_2D = station_a.get_distance_to(station_b)
-        d_3D = station_a.get_3d_distance_to(station_b)
-
-        if self.parameters.imt.interfered_with:
-            freq = self.param_system.frequency
-        else:
-            freq = self.parameters.imt.frequency
-
         if station_a.station_type is StationType.FSS_SS or \
            station_a.station_type is StationType.HAPS or \
            station_a.station_type is StationType.RNS:
@@ -204,6 +201,15 @@ class Simulation(ABC, Observable):
            station_a.station_type is StationType.FS or \
            station_a.station_type is StationType.RNS or \
            station_a.station_type is StationType.RAS:
+            # Calculate distance from transmitters to receivers. The result is a
+            # num_station_a x num_station_b
+            d_2D = station_a.get_distance_to(station_b)
+            d_3D = station_a.get_3d_distance_to(station_b)
+            
+            if self.parameters.imt.interfered_with:
+                freq = self.param_system.frequency
+            else:
+                freq = self.parameters.imt.frequency
 
             # System <-> IMT antenna gains
             if station_b.station_type is StationType.IMT_UE:
@@ -244,7 +250,12 @@ class Simulation(ABC, Observable):
 
             self.system_imt_antenna_gain = gain_a
             self.imt_system_antenna_gain = gain_b
+        # IMT <-> IMT
         else:
+            d_2D = self.bs_to_ue_d_2D
+            d_3D = self.bs_to_ue_d_3D
+            freq = self.parameters.imt.frequency
+            
             path_loss = propagation.get_loss(distance_3D=d_3D,
                                              distance_2D=d_2D,
                                              frequency=self.parameters.imt.frequency*np.ones(d_2D.shape),
@@ -313,8 +324,13 @@ class Simulation(ABC, Observable):
         Select K UEs randomly from all the UEs linked to one BS as “chosen”
         UEs. These K “chosen” UEs will be scheduled during this snapshot.
         """
-        self.bs_to_ue_phi, self.bs_to_ue_theta = \
-            self.bs.get_pointing_vector_to(self.ue)
+        if self.wrap_around_enabled:
+            self.bs_to_ue_d_2D, self.bs_to_ue_d_3D, self.bs_to_ue_phi, self.bs_to_ue_theta = \
+                self.bs.get_dist_angles_wrap_around(self.ue)
+        else:
+            self.bs_to_ue_d_2D = self.bs.get_distance_to(self.ue)
+            self.bs_to_ue_d_3D = self.bs.get_3d_distance_to(self.ue)
+            self.bs_to_ue_phi, self.bs_to_ue_theta = self.bs.get_pointing_vector_to(self.ue)
 
         bs_active = np.where(self.bs.active)[0]
         for bs in bs_active:
@@ -355,14 +371,14 @@ class Simulation(ABC, Observable):
         Calculates the gains of antennas in station_1 in the direction of
         station_2
         """
-        phi, theta = station_1.get_pointing_vector_to(station_2)
-
         station_1_active = np.where(station_1.active)[0]
         station_2_active = np.where(station_2.active)[0]
 
         # Initialize variables (phi, theta, beams_idx)
         if(station_1.station_type is StationType.IMT_BS):
             if(station_2.station_type is StationType.IMT_UE):
+                phi = self.bs_to_ue_phi
+                theta = self.bs_to_ue_theta
                 beams_idx = self.bs_to_ue_beam_rbs[station_2_active]
             elif(station_2.station_type is StationType.FSS_SS or \
                  station_2.station_type is StationType.FSS_ES or \
@@ -370,6 +386,7 @@ class Simulation(ABC, Observable):
                  station_2.station_type is StationType.FS or \
                  station_2.station_type is StationType.RNS or \
                  station_2.station_type is StationType.RAS):
+                phi, theta = station_1.get_pointing_vector_to(station_2)
                 phi = np.repeat(phi,self.parameters.imt.ue_k,0)
                 theta = np.repeat(theta,self.parameters.imt.ue_k,0)
                 beams_idx = np.tile(np.arange(self.parameters.imt.ue_k),self.bs.num_stations)
@@ -380,6 +397,7 @@ class Simulation(ABC, Observable):
                 beams_idx = np.tile(np.arange(self.parameters.imt.ue_k),self.bs.num_stations)
 
         elif(station_1.station_type is StationType.IMT_UE):
+            phi, theta = station_1.get_pointing_vector_to(station_2)
             beams_idx = np.zeros(len(station_2_active),dtype=int)
 
         elif(station_1.station_type is StationType.FSS_SS or \
@@ -388,6 +406,7 @@ class Simulation(ABC, Observable):
              station_1.station_type is StationType.FS or \
              station_1.station_type is StationType.RNS or \
              station_1.station_type is StationType.RAS):
+            phi, theta = station_1.get_pointing_vector_to(station_2)
             beams_idx = np.zeros(len(station_2_active),dtype=int)
 
         # Calculate gains

--- a/sharc/station_factory.py
+++ b/sharc/station_factory.py
@@ -104,6 +104,9 @@ class StationFactory(object):
         elif param.spectral_mask == "3GPP 36.104":
             imt_base_stations.spectral_mask = SpectralMask3Gpp(StationType.IMT_BS,param.frequency,\
                                                                param.bandwidth)
+            
+        if param.topology == 'MACROCELL' or param.topology == 'HOTSPOT':
+            imt_base_stations.intesite_dist = param.intersite_distance
 
         return imt_base_stations
 
@@ -257,6 +260,9 @@ class StationFactory(object):
                                                    param.bandwidth)
 
         imt_ue.spectral_mask.set_mask()
+        
+        if param.topology == 'MACROCELL' or param.topology == 'HOTSPOT':
+            imt_ue.intersite_dist = param.intersite_distance
 
         return imt_ue
 

--- a/sharc/station_manager.py
+++ b/sharc/station_manager.py
@@ -51,6 +51,7 @@ class StationManager(object):
         self.center_freq = np.empty(n)
         self.spectral_mask = None
         self.station_type = StationType.NONE
+        self.intersite_dist = 0.0
 
     def get_station_list(self, id=None) -> list:
         if(id is None):
@@ -107,6 +108,65 @@ class StationManager(object):
         idx0 = np.where(distance == 0)
         distance[idx0] = np.nan
         return distance
+    
+    def get_dist_angles_wrap_around(self, station) -> np.array:
+        """
+        Calcualtes distances and angles using the wrap around technique
+        Parameters:
+            station (StationManager): station to which calculate the distances
+                and angles
+        Returns:
+            distance_2D (np.array): 2D distance between stations
+            distance_3D (np.array): 3D distance between stations
+            phi (np.array): azimuth of pointing vector to other stations
+            theta (np.array): elevation of pointing vector to other stations
+        """
+        # Initialize variables
+        distance_3D = np.empty([self.num_stations, station.num_stations])
+        distance_2D = np.inf*np.ones_like(distance_3D)
+        cluster_num = np.zeros_like(distance_3D, dtype=int)
+        
+        # Cluster coordinates
+        cluster_x = np.array([station.x,
+                              station.x + 3.5*self.intersite_dist,
+                              station.x - 0.5*self.intersite_dist,
+                              station.x - 4.0*self.intersite_dist,
+                              station.x - 3.5*self.intersite_dist,
+                              station.x + 0.5*self.intersite_dist,
+                              station.x + 4.0*self.intersite_dist])
+    
+        cluster_y = np.array([station.y,
+                              station.y + 1.5*np.sqrt(3.0)*self.intersite_dist,
+                              station.y + 2.5*np.sqrt(3.0)*self.intersite_dist,
+                              station.y + 1.0*np.sqrt(3.0)*self.intersite_dist,
+                              station.y - 1.5*np.sqrt(3.0)*self.intersite_dist,
+                              station.y - 2.5*np.sqrt(3.0)*self.intersite_dist,
+                              station.y - 1.0*np.sqrt(3.0)*self.intersite_dist])
+        
+        # Calculate 2D distance
+        temp_distance = np.zeros_like(distance_2D)
+        for k,(x,y) in enumerate(zip(cluster_x,cluster_y)):                
+            temp_distance = np.sqrt(np.power(x - self.x[:,np.newaxis], 2) +
+                                    np.power(y - self.y[:,np.newaxis], 2))
+            is_shorter = temp_distance < distance_2D
+            distance_2D[is_shorter] = temp_distance[is_shorter]
+            cluster_num[is_shorter] = k
+            
+        # Calculate 3D distance
+        distance_3D = np.sqrt(np.power(distance_2D, 2) +
+                              np.power(station.height - self.height[:,np.newaxis], 2))
+            
+        # Calcualte pointing vector
+        point_vec_x = cluster_x[cluster_num,np.arange(station.num_stations)] \
+                      - self.x[:,np.newaxis]
+        point_vec_y = cluster_y[cluster_num,np.arange(station.num_stations)] \
+                      - self.y[:,np.newaxis]
+        point_vec_z = station.height - self.height[:,np.newaxis]
+        
+        phi = np.array(np.rad2deg(np.arctan2(point_vec_y,point_vec_x)),ndmin=2)
+        theta = np.rad2deg(np.arccos(point_vec_z/distance_3D))
+                
+        return distance_2D, distance_3D, phi, theta
 
     def get_elevation(self, station) -> np.array:
         """

--- a/sharc/station_manager.py
+++ b/sharc/station_manager.py
@@ -109,7 +109,7 @@ class StationManager(object):
         distance[idx0] = np.nan
         return distance
     
-    def get_dist_angles_wrap_around(self, station) -> np.array:
+    def get_dist_angles_wrap_around(self, station,return_dist=False) -> np.array:
         """
         Calcualtes distances and angles using the wrap around technique
         Parameters:
@@ -155,6 +155,8 @@ class StationManager(object):
         # Calculate 3D distance
         distance_3D = np.sqrt(np.power(distance_2D, 2) +
                               np.power(station.height - self.height[:,np.newaxis], 2))
+        
+        if return_dist: return distance_2D, distance_3D
             
         # Calcualte pointing vector
         point_vec_x = cluster_x[cluster_num,np.arange(station.num_stations)] \

--- a/tests/test_adjacent_channel.py
+++ b/tests/test_adjacent_channel.py
@@ -31,6 +31,7 @@ class SimulationAdjacentTest(unittest.TestCase):
         self.param.general.suppress_large_results = False
 
         self.param.imt.topology = "SINGLE_BS"
+        self.param.imt.wrap_around = False
         self.param.imt.num_macrocell_sites = 19
         self.param.imt.num_clusters = 2
         self.param.imt.intersite_distance = 150
@@ -181,6 +182,8 @@ class SimulationAdjacentTest(unittest.TestCase):
         # test connection method
         self.simulation.connect_ue_to_bs()
         self.assertEqual(self.simulation.link, {0: [0,1], 1: [2,3]})
+        self.simulation.select_ue(random_number_gen)
+        self.simulation.link = {0:[0,1],1:[2,3]}
 
         # We do not test the selection method here because in this specific
         # scenario we do not want to change the order of the UE's
@@ -274,6 +277,8 @@ class SimulationAdjacentTest(unittest.TestCase):
         # test connection method
         self.simulation.connect_ue_to_bs()
         self.assertEqual(self.simulation.link, {0: [0,1], 1: [2,3]})
+        self.simulation.select_ue(random_number_gen)
+        self.simulation.link = {0:[0,1],1:[2,3]}
 
         # We do not test the selection method here because in this specific
         # scenario we do not want to change the order of the UE's

--- a/tests/test_simulation_downlink.py
+++ b/tests/test_simulation_downlink.py
@@ -31,6 +31,7 @@ class SimulationDownlinkTest(unittest.TestCase):
         self.param.general.suppress_large_results = False
 
         self.param.imt.topology = "SINGLE_BS"
+        self.param.imt.wrap_around = False
         self.param.imt.num_macrocell_sites = 19
         self.param.imt.num_clusters = 2
         self.param.imt.intersite_distance = 150
@@ -220,6 +221,8 @@ class SimulationDownlinkTest(unittest.TestCase):
 
         # test connection method
         self.simulation.connect_ue_to_bs()
+        self.simulation.select_ue(random_number_gen)
+        self.simulation.link = {0:[0,1],1:[2,3]}
         self.assertEqual(self.simulation.link, {0: [0,1], 1: [2,3]})
 
         # We do not test the selection method here because in this specific
@@ -368,6 +371,8 @@ class SimulationDownlinkTest(unittest.TestCase):
                                                                                 self.param, random_number_gen)
 
         self.simulation.connect_ue_to_bs()
+        self.simulation.select_ue(random_number_gen)
+        self.simulation.link = {0:[0,1],1:[2,3]}
         self.simulation.coupling_loss_imt = self.simulation.calculate_coupling_loss(self.simulation.bs,
                                                                                     self.simulation.ue,
                                                                                     self.simulation.propagation_imt)
@@ -497,6 +502,10 @@ class SimulationDownlinkTest(unittest.TestCase):
                                                                                    self.param, random_number_gen)
 
         self.simulation.connect_ue_to_bs()
+        self.simulation.select_ue(random_number_gen)
+        self.simulation.link = {0:[0,1],1:[2,3]}
+        self.simulation.select_ue(random_number_gen)
+        self.simulation.link = {0:[0,1],1:[2,3]}
         self.simulation.coupling_loss_imt = self.simulation.calculate_coupling_loss(self.simulation.bs,
                                                                                     self.simulation.ue,
                                                                                     self.simulation.propagation_imt)

--- a/tests/test_simulation_downlink_haps.py
+++ b/tests/test_simulation_downlink_haps.py
@@ -31,6 +31,7 @@ class SimulationDownlinkHapsTest(unittest.TestCase):
         self.param.general.suppress_large_results = False
 
         self.param.imt.topology = "SINGLE_BS"
+        self.param.imt.wrap_around = False
         self.param.imt.num_macrocell_sites = 19
         self.param.imt.num_clusters = 2
         self.param.imt.intersite_distance = 150
@@ -184,6 +185,8 @@ class SimulationDownlinkHapsTest(unittest.TestCase):
         self.simulation.propagation_system = PropagationFactory.create_propagation(self.param.haps.channel_model,
                                                                                    self.param, random_number_gen)
         self.simulation.connect_ue_to_bs()
+        self.simulation.select_ue(random_number_gen)
+        self.simulation.link = {0:[0,1],1:[2,3]}
         self.simulation.coupling_loss_imt = self.simulation.calculate_coupling_loss(self.simulation.bs,
                                                                                     self.simulation.ue,
                                                                                     self.simulation.propagation_imt)

--- a/tests/test_simulation_full_duplex.py
+++ b/tests/test_simulation_full_duplex.py
@@ -32,6 +32,7 @@ class SimulationFullDuplexTest(unittest.TestCase):
         self.param.general.suppress_large_results = False
         
         self.param.imt.topology = "SINGLE_BS"
+        self.param.imt.wrap_around = False
         self.param.imt.num_macrocell_sites = 19
         self.param.imt.num_clusters = 2
         self.param.imt.intersite_distance = 150

--- a/tests/test_simulation_indoor.py
+++ b/tests/test_simulation_indoor.py
@@ -29,6 +29,7 @@ class SimulationIndoorTest(unittest.TestCase):
         self.param.general.results_format = "SAMPLES"
 
         self.param.imt.topology = "INDOOR"
+        self.param.imt.wrap_around = False
         self.param.imt.num_macrocell_sites = 19
         self.param.imt.num_clusters = 1
         self.param.imt.intersite_distance = 339

--- a/tests/test_simulation_uplink.py
+++ b/tests/test_simulation_uplink.py
@@ -30,6 +30,7 @@ class SimulationUplinkTest(unittest.TestCase):
         self.param.general.suppress_large_results = False
 
         self.param.imt.topology = "SINGLE_BS"
+        self.param.imt.wrap_around = True
         self.param.imt.num_macrocell_sites = 19
         self.param.imt.num_clusters = 2
         self.param.imt.intersite_distance = 150
@@ -220,6 +221,8 @@ class SimulationUplinkTest(unittest.TestCase):
         # test connection method
         self.simulation.connect_ue_to_bs()
         self.assertEqual(self.simulation.link, {0: [0,1], 1: [2,3]})
+        self.simulation.select_ue(random_number_gen)
+        self.simulation.link = {0:[0,1],1:[2,3]}
 
         # We do not test the selection method here because in this specific
         # scenario we do not want to change the order of the UE's
@@ -365,6 +368,8 @@ class SimulationUplinkTest(unittest.TestCase):
         self.simulation.ue.active = np.ones(4, dtype=bool)
 
         self.simulation.connect_ue_to_bs()
+        self.simulation.select_ue(random_number_gen)
+        self.simulation.link = {0:[0,1],1:[2,3]}
 
         # We do not test the selection method here because in this specific
         # scenario we do not want to change the order of the UE's
@@ -547,10 +552,8 @@ class SimulationUplinkTest(unittest.TestCase):
         self.simulation.ue.active = np.ones(4, dtype=bool)
 
         self.simulation.connect_ue_to_bs()
-
-        # We do not test the selection method here because in this specific
-        # scenario we do not want to change the order of the UE's
-        #self.simulation.select_ue()
+        self.simulation.select_ue(random_number_gen)
+        self.simulation.link = {0:[0,1],1:[2,3]}
 
         self.simulation.propagation_imt = PropagationFactory.create_propagation(self.param.imt.channel_model,
                                                                                 self.param, random_number_gen)
@@ -628,7 +631,7 @@ class SimulationUplinkTest(unittest.TestCase):
         self.simulation.initialize()
 
         eps = 1e-2
-        random_number_gen = np.random.RandomState()
+        random_number_gen = np.random.RandomState(101)
 
         # Set scenario
         self.simulation.bs = StationFactory.generate_imt_base_stations(self.param.imt,
@@ -676,6 +679,8 @@ class SimulationUplinkTest(unittest.TestCase):
                                           [180.0, 170.935, 180.0, 120.0  ]]),atol=eps)
         npt.assert_allclose(theta,np.array([[95.143, 95.143, 91.718, 91.430],
                                             [91.718, 91.624, 95.143, 95.143]]),atol=eps)
+        self.simulation.bs_to_ue_phi = phi
+        self.simulation.bs_to_ue_theta = theta
 
         # Add beams by brute force: since the SimulationUplink.select_ue()
         # method shufles the link dictionary, the order of the beams cannot be

--- a/tests/test_station_manager.py
+++ b/tests/test_station_manager.py
@@ -74,6 +74,7 @@ class StationManagerTest(unittest.TestCase):
         self.station_manager.x = np.array([10, 20, 30])
         self.station_manager.y = np.array([15, 25, 35])
         self.station_manager.height = np.array([1, 2, 3])
+        self.station_manager.intersite_dist = 100.0
         # this is for downlink
         self.station_manager.tx_power = dict({0: [27, 30], 1: [35], 2: [40]})
         self.station_manager.rx_power = np.array([-50, -35, -10])
@@ -85,6 +86,7 @@ class StationManagerTest(unittest.TestCase):
         self.station_manager2.x = np.array([100, 200])
         self.station_manager2.y = np.array([105, 250])
         self.station_manager2.height = np.array([4, 5])
+        self.station_manager2.intersite_dist = 100.0
         # this is for downlink
         self.station_manager2.tx_power = dict({0: [25], 1: [28,35]})
         self.station_manager2.rx_power = np.array([-50, -35])
@@ -96,6 +98,7 @@ class StationManagerTest(unittest.TestCase):
         self.station_manager3.x = np.array([300])
         self.station_manager3.y = np.array([400])
         self.station_manager3.height = np.array([2])
+        self.station_manager3.intersite_dist = 100.0
         # this is for uplink
         self.station_manager3.tx_power = 22
         self.station_manager3.rx_power = np.array([-50,-35])
@@ -323,6 +326,38 @@ class StationManagerTest(unittest.TestCase):
                                    [  99,  274.096]])
         distance = self.station_manager.get_3d_distance_to(self.station_manager2)
         npt.assert_allclose(distance, ref_distance, atol=1e-2)
+        
+    def test_wrap_around(self):
+        self.station_manager = StationManager(2)
+        self.station_manager.x = np.array([0, 150])
+        self.station_manager.y = np.array([0, -32])
+        self.station_manager.height = np.array([4, 5])
+        self.station_manager.intersite_dist = 100.0
+        
+        self.station_manager2 = StationManager(3)
+        self.station_manager2.x = np.array([10, 200,   30])
+        self.station_manager2.y = np.array([15, 250, -350])
+        self.station_manager2.height = np.array([1, 2, 3])
+        
+        # 2D Distance
+        d_2D, d_3D, phi, theta = self.station_manager.get_dist_angles_wrap_around(self.station_manager2)
+        ref_d_2D = np.asarray([[  18.03,  150.32,   85.39],
+                               [ 147.68,  181.12,  205.25]])
+        npt.assert_allclose(d_2D, ref_d_2D, atol=1e-2)
+        
+        # 3D Distance
+        ref_d_3D = np.asarray([[  18.27,  150.33,   85.39],
+                               [ 147.73,  181.15,  205.26]])
+        npt.assert_allclose(d_3D, ref_d_3D, atol=1e-2)
+        
+        # Point vec
+        ref_phi = np.asarray([[  56.31, -176.26 ,  103.55],
+                              [ 161.44,  -56.49,   145.92]])
+        npt.assert_allclose(phi, ref_phi, atol=1e-2)
+        
+        ref_theta = np.asarray([[ 99.45,  90.76,  90.67],
+                                [ 91.55,  90.95,  90.56]])
+        npt.assert_allclose(theta,ref_theta, atol=1e-2)
 
     def test_pointing_vector_to(self):
         eps = 1e-1


### PR DESCRIPTION
Wrap around is enabled when:

- `wrap_around` parameter in IMT section is true **and**
- Topology is either `MACROCELL` or `HOTSPOT` and
- `num_clusters` parameter in section IMT is set to 1